### PR TITLE
Possible fix for #20 ADFS based authentication

### DIFF
--- a/SharePointAPI.py
+++ b/SharePointAPI.py
@@ -1,0 +1,66 @@
+import re
+import requests
+import xml.dom.minidom as dom
+
+class spListsAPI():
+    """
+    A SharePoint Online lists API. For a full listing of commands available to your
+    SP site, check your https://tenant.sharepoint.com/sites/subsite/_vti_bin/lists.asmx file.
+    
+    This class is intended to be used on the driver code side of the SharePointSession class
+    of sharepy
+    An adaptation of https://github.com/thybag/PHP-SharePoint-Lists-API/
+    """
+
+    def __init__(self, SP_SESSION=None):
+        self.SP_SESSION = SP_SESSION
+        self.spsTenantUrl = SP_SESSION.tenantUrl
+        self.spsBase = "https://"+ re.search('((^.+/sites/[^/]+/))', SP_SESSION.site).group(1) + "_vti_bin/Lists.asmx"
+        self.SP_SESSION.headers.update({"Content-Type":"text/xml; charset=utf-8", "Content-Length":"length", "Host":self.SP_SESSION.tenantUrl})
+
+    '''
+    Requires no extra data in the SOAP envelope
+    '''
+    def GetListCollection(self):
+        self.SP_SESSION.headers.update({"SOAPAction": "http://schemas.microsoft.com/sharepoint/soap/GetListCollection"})
+        envelope = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">  <soap:Body>    <GetListCollection xmlns="http://schemas.microsoft.com/sharepoint/soap/" />  </soap:Body></soap:Envelope>'
+        res = requests.post(url=self.spsBase, data=envelope, headers=self.SP_SESSION.headers, cookies=self.SP_SESSION.cookies)
+        
+        return self.getArrayFromElementsByTagName(res.text, 'List')
+
+    '''
+    Requires the following (at the least) in the SOAP envelope:
+        listName
+    Optional items in the envelope:
+        viewName
+        query
+        viewFields
+        rowLimit
+        QueryOptions
+        webID
+    Note: If rowLimit is not provided, SharePoint will default to a response of 100 items
+    '''
+    def GetListItems(self, listName, viewName='', query='', viewFields='', rowLimit='', QueryOptions='', webID=''):
+        self.SP_SESSION.headers.update({"SOAPAction": "http://schemas.microsoft.com/sharepoint/soap/GetListItems"})
+        envelopeTemplate = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">  <soap:Body>    <GetListItems xmlns="http://schemas.microsoft.com/sharepoint/soap/">      <listName>{listName}</listName>      <viewName>{viewName}</viewName>      <query>{query}</query>      <viewFields>{viewFields}</viewFields>      <rowLimit>{rowLimit}</rowLimit>      <QueryOptions>{QueryOptions}</QueryOptions>      <webID>{webID}</webID>    </GetListItems>  </soap:Body></soap:Envelope>'
+        envelope = envelopeTemplate.format(listName=listName, viewName=viewName, query=query, viewFields=viewFields, rowLimit=rowLimit, QueryOptions=QueryOptions, webID=webID)
+        res = requests.post(url=self.spsBase, data=envelope, headers=self.SP_SESSION.headers, cookies=self.SP_SESSION.cookies)
+        
+        return self.getArrayFromElementsByTagName(res.text, 'z:row')
+        
+    #used to grab the <tag> nodes from the response
+    # Returns a JSON
+    def getArrayFromElementsByTagName (self, rawXML, tag, namespace=None):
+        doc = dom.parseString(rawXML)
+        nodes = doc.getElementsByTagName(tag)
+        result = []
+        #print(nodes[1].getAttribute('DocTemplateUrl'))
+        for element in nodes:
+            pairs = {}
+            #print(node.attributes)
+            for attrName, attrValue in element.attributes.items():
+                pairs[attrName] = attrValue
+            result.append(pairs)
+            
+        return result
+

--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,4 @@
 from .session import SharePointSession
 from .session import connect
 from .session import load
+from .SharePointAPI import spListsAPI

--- a/customStsSaml-template.xml
+++ b/customStsSaml-template.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" 
+    xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" 
+    xmlns:saml="urn:oasis:names:tc:SAML:1.0:assertion" 
+    xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" 
+    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" 
+    xmlns:wsa="http://www.w3.org/2005/08/addressing" 
+    xmlns:wssc="http://schemas.xmlsoap.org/ws/2005/02/sc" 
+    xmlns:wst="http://schemas.xmlsoap.org/ws/2005/02/trust">
+    <s:Header>
+        <wsa:Action s:mustUnderstand="1">http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue</wsa:Action>
+        <wsa:To s:mustUnderstand="1">{adfs}</wsa:To>
+        <wsa:MessageID>{guid}</wsa:MessageID>
+        <ps:AuthInfo xmlns:ps="http://schemas.microsoft.com/Passport/SoapServices/PPCRL" Id="PPAuthInfo">
+            <ps:HostingApp>Managed IDCRL</ps:HostingApp>
+            <ps:BinaryVersion>6</ps:BinaryVersion>
+            <ps:UIVersion>1</ps:UIVersion>
+            <ps:Cookies></ps:Cookies>
+            <ps:RequestParams>AQAAAAIAAABsYwQAAAAxMDMz</ps:RequestParams>
+        </ps:AuthInfo>
+        <wsse:Security>
+            <wsse:UsernameToken wsu:Id="user">
+                <wsse:Username>{username}</wsse:Username>
+                <wsse:Password>{password}</wsse:Password>
+            </wsse:UsernameToken>
+            <wsu:Timestamp Id="Timestamp">
+                <wsu:Created>{created}</wsu:Created>
+                <wsu:Expires>{expires}</wsu:Expires>
+            </wsu:Timestamp>
+        </wsse:Security>
+    </s:Header>
+    <s:Body>
+        <wst:RequestSecurityToken Id="RST0">
+            <wst:RequestType>http://schemas.xmlsoap.org/ws/2005/02/trust/Issue</wst:RequestType>
+            <wsp:AppliesTo>
+                <wsa:EndpointReference>
+                    <wsa:Address>{realm}</wsa:Address>
+                </wsa:EndpointReference>
+            </wsp:AppliesTo>
+            <wst:KeyType>http://schemas.xmlsoap.org/ws/2005/05/identity/NoProofKey</wst:KeyType>
+        </wst:RequestSecurityToken>
+    </s:Body>
+</s:Envelope>

--- a/msoSaml-template.xml
+++ b/msoSaml-template.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<S:Envelope xmlns:S="http://www.w3.org/2003/05/soap-envelope" 
+    xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" 
+    xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" 
+    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" 
+    xmlns:wsa="http://www.w3.org/2005/08/addressing" 
+    xmlns:wst="http://schemas.xmlsoap.org/ws/2005/02/trust">
+    <S:Header>
+        <wsa:Action S:mustUnderstand="1">http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue</wsa:Action>
+        <wsa:To S:mustUnderstand="1">https://login.microsoftonline.com/rst2.srf</wsa:To>
+        <ps:AuthInfo xmlns:ps="http://schemas.microsoft.com/LiveID/SoapServices/v1" Id="PPAuthInfo">
+            <ps:BinaryVersion>5</ps:BinaryVersion>
+            <ps:HostingApp>Managed IDCRL</ps:HostingApp>
+        </ps:AuthInfo>
+        <wsse:Security>{customSTSAssertion}</wsse:Security>
+    </S:Header>
+    <S:Body>
+        <wst:RequestSecurityToken xmlns:wst="http://schemas.xmlsoap.org/ws/2005/02/trust" Id="RST0">
+            <wst:RequestType>http://schemas.xmlsoap.org/ws/2005/02/trust/Issue</wst:RequestType>
+            <wsp:AppliesTo>
+                <wsa:EndpointReference>
+                    <wsa:Address>{msoEndpoint}</wsa:Address>
+                </wsa:EndpointReference>
+            </wsp:AppliesTo>
+            <wsp:PolicyReference URI="MBI"></wsp:PolicyReference>
+        </wst:RequestSecurityToken>
+    </S:Body>
+</S:Envelope>


### PR DESCRIPTION
#20 
This library originally did not work for my SharePoint environment either, but I wrote a fix for it in a custom SharePoint Token Service (STS) + Microsoft Online (MSO) Authentication configuration to replicate [this diagram](https://docs.microsoft.com/en-us/sharepoint/authentication)
Created the SharePointAPI class to help deal with interactions with sharepoint lists. Far as I can tell will work with non ADFS SPO implementations as well as my own ADFS version. Use is the same as any other connection except to set adfsAuth = True

Added _spoAdfsAuth member function to SharePointSession class to handle authenticating with custom STS based ADFS SPO implementations. Documentation for that is [here](https://blogs.technet.microsoft.com/sharepointdevelopersupport/2018/02/07/sharepoint-online-active-authentication/).

To handle this new authentication method, also created customStsSamlm and msoSaml xml templates.

Here is a test drive

```
import sharepy as session
from sharepy import spListsAPI

connect_url = "https://tenant.sharepoint.com/sites/subsite/"
s = session.connect(connect_url, username="user@domain.com", password="pass", adfsAuth=True)
shareLists = spListsAPI(s)
print(shareLists.GetListCollection())
print(shareLists.GetListItems('Case-insensitive List Name'))
```