### PR TITLE
Set content-type in __call__ only if not present in headers

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -158,8 +158,11 @@ class SharePointADFS(requests.auth.AuthBase):
     def __call__(self, request):
         """Inject cookies into requests as they are made"""
         if self.cookie and self.digest:
-            request.headers.update({"Content-Type": "text/xml; charset=utf-8",
-                                    "Cookie" : self.cookie})
+            if 'Content-Type' in request.headers:
+                request.headers.update({"Cookie" : self.cookie})
+            else:
+                request.headers.update({"Content-Type": "text/xml; charset=utf-8",
+                                        "Cookie" : self.cookie})
         return request
 
     def login(self, site):

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,32 @@
+# --------------------------------------------------------------------------
+#
+# GNU GENERAL PUBLIC LICENSE
+# --------------------------------------------------------------------------
+
+from setuptools import setup, find_packages
+
+setup(
+    name='sharepy',
+    version='1.0.0',
+    author='Authors',
+    packages=find_packages(exclude=["tests", "tests.*"]),
+    url=("https://github.com/ljr55555/sharepy"),
+    license='MIT License',
+    description='Python sharepoint wrapper.',
+    long_description=open('README.md').read(),
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'License :: OSI Approved :: GNU GENERAL PUBLIC LICENSE',
+        'Topic :: Software Development'],
+    install_requires=[
+        "requests~=2.16"
+    ],
+)


### PR DESCRIPTION
When attempting a POST to create a list item, I get an error from SharePoint Online stating that content-type is missing or invalid. Using dump from requests_toolbelt.utils, I find that content-type is set to "text/xml; charset=utf-8". Per Microsoft's documentation on [creating a list item](https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/working-with-lists-and-list-items-with-rest#working-with-list-items-by-using-rest), content-type needs to be "application/json;odata=verbose". 

While I am setting content-type in my post call, it appears to be overwritten by the header update in __call__  -- by modifying the __call__ function to only update the header content-type when content-type is not set, I am able to successfully create list items. 