### PR TITLE
Improve XML parsing for ADFS auth

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -4,7 +4,6 @@ from getpass import getpass
 from datetime import datetime, timedelta
 from xml.sax.saxutils import escape
 from uuid import uuid4
-import re
 
 import requests
 
@@ -268,9 +267,10 @@ class SharePointADFS(requests.auth.AuthBase):
 
             # Parse digest text and timeout from XML
             try:
-                self.digest = re.search(r"<DigestValue>(.+)</DigestValue>", response.text).group(1)
-                timeout = int(re.search(r"Seconds>(\d+)<", response.text).group(1))
-            except Exception:
+                root = et.fromstring(response.text)
+                self.digext = root.find(".//DigestValue").text
+                timeout = root.find(".//TimeoutSeconds").text
+            except (AttributeError, et.ParseError):
                 print("Digest request failed")
                 return
 

--- a/auth.py
+++ b/auth.py
@@ -10,12 +10,13 @@ import requests
 
 # XML namespace URIs
 ns = {
-    "saml": "urn:oasis:names:tc:SAML:1.0:assertion",
-    "wsse": "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd",
-    "psf": "http://schemas.microsoft.com/Passport/SoapServices/SOAPFault",
     "d": "http://schemas.microsoft.com/ado/2007/08/dataservices",
-    "S": "http://www.w3.org/2003/05/soap-envelope",
     "ds": "http://www.w3.org/2000/09/xmldsig#",
+    "psf": "http://schemas.microsoft.com/Passport/SoapServices/SOAPFault",
+    "S": "http://www.w3.org/2003/05/soap-envelope",
+    "saml": "urn:oasis:names:tc:SAML:1.0:assertion",
+    "soap": "http://schemas.microsoft.com/sharepoint/soap/",
+    "wsse": "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd",
 }
 # Register namespaces for XML serialisation
 for alias, uri in ns.items():
@@ -272,8 +273,8 @@ class SharePointADFS(requests.auth.AuthBase):
             # Parse digest text and timeout from XML
             try:
                 root = et.fromstring(response.text)
-                self.digext = root.find(".//DigestValue").text
-                timeout = root.find(".//TimeoutSeconds").text
+                self.digext = root.find(".//soap:DigestValue", ns).text
+                timeout = root.find(".//soap:TimeoutSeconds", ns).text
             except (AttributeError, et.ParseError):
                 print("Digest request failed")
                 return

--- a/auth.py
+++ b/auth.py
@@ -8,14 +8,18 @@ from uuid import uuid4
 import requests
 
 
-# XML namespace URLs
+# XML namespace URIs
 ns = {
     "saml": "urn:oasis:names:tc:SAML:1.0:assertion",
     "wsse": "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd",
     "psf": "http://schemas.microsoft.com/Passport/SoapServices/SOAPFault",
     "d": "http://schemas.microsoft.com/ado/2007/08/dataservices",
-    "S": "http://www.w3.org/2003/05/soap-envelope"
+    "S": "http://www.w3.org/2003/05/soap-envelope",
+    "ds": "http://www.w3.org/2000/09/xmldsig#",
 }
+# Register namespaces for XML serialisation
+for alias, uri in ns.items():
+    et.register_namespace(alias, uri)
 
 
 def detect(username, password=None):
@@ -202,7 +206,7 @@ class SharePointADFS(requests.auth.AuthBase):
         # Parse and extract token from returned XML
         try:
             root = et.fromstring(response.text)
-            samlAssertion = et.tostring(root.find(".//saml:Assertion"))
+            samlAssertion = et.tostring(root.find(".//saml:Assertion", ns), encoding='unicode')
         except (AttributeError, et.ParseError):
             print("Error getting security token")
             return

--- a/auth.py
+++ b/auth.py
@@ -216,8 +216,8 @@ class SharePointADFS(requests.auth.AuthBase):
         with open(os.path.join(os.path.dirname(__file__),
                   "saml-templates/sp-adfs-stsBinaryToken.xml"), "r") as file:
             saml = file.read()
-        saml = saml.format(customSTSAssertion=samlAssertion,
-                           msoEndpoint="sharepoint.com")
+        saml = saml.format(assertion=samlAssertion,
+                           endpoint="sharepoint.com")
         response = requests.post(url=MSO_AUTH_URL, data=saml, headers=headers)
         # Parse and extract token from returned XML
         try:

--- a/auth.py
+++ b/auth.py
@@ -173,9 +173,7 @@ class SharePointADFS(requests.auth.AuthBase):
         """Request authentication token from ADFS server"""
         # Generate timestamps and GUID
         created = datetime.utcnow()
-        createdStr = str(datetime.utcnow()).replace(' ', 'T') + 'Z'
         expires = created + timedelta(minutes=10)
-        expiresStr = str(expires).replace(' ', 'T') + 'Z'
         message_id = str(uuid4())
 
         # Load SAML request template
@@ -192,8 +190,8 @@ class SharePointADFS(requests.auth.AuthBase):
                            password=escape(password),
                            auth_url=self.auth_url,
                            message_id=message_id,
-                           created=createdStr,
-                           expires=expiresStr)
+                           created=created.isoformat() + "Z",
+                           expires=expires.isoformat() + "Z")
 
         # Request security token from Microsoft Online
         print("Requesting security token...\r", end="")

--- a/saml-templates/sp-adfs-stsBinaryToken.xml
+++ b/saml-templates/sp-adfs-stsBinaryToken.xml
@@ -12,14 +12,14 @@
             <ps:BinaryVersion>5</ps:BinaryVersion>
             <ps:HostingApp>Managed IDCRL</ps:HostingApp>
         </ps:AuthInfo>
-        <wsse:Security>{customSTSAssertion}</wsse:Security>
+        <wsse:Security>{assertion}</wsse:Security>
     </S:Header>
     <S:Body>
         <wst:RequestSecurityToken xmlns:wst="http://schemas.xmlsoap.org/ws/2005/02/trust" Id="RST0">
             <wst:RequestType>http://schemas.xmlsoap.org/ws/2005/02/trust/Issue</wst:RequestType>
             <wsp:AppliesTo>
                 <wsa:EndpointReference>
-                    <wsa:Address>{msoEndpoint}</wsa:Address>
+                    <wsa:Address>{endpoint}</wsa:Address>
                 </wsa:EndpointReference>
             </wsp:AppliesTo>
             <wsp:PolicyReference URI="MBI"></wsp:PolicyReference>

--- a/saml-templates/sp-online.xml
+++ b/saml-templates/sp-online.xml
@@ -1,30 +1,30 @@
 <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"
-      xmlns:a="http://www.w3.org/2005/08/addressing"
-      xmlns:u="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
-  <s:Header>
-    <a:Action s:mustUnderstand="1">http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue</a:Action>
-    <a:ReplyTo>
-      <a:Address>http://www.w3.org/2005/08/addressing/anonymous</a:Address>
-    </a:ReplyTo>
-    <a:To s:mustUnderstand="1">https://login.microsoftonline.com/extSTS.srf</a:To>
-    <o:Security s:mustUnderstand="1"
-       xmlns:o="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
-      <o:UsernameToken>
-        <o:Username>{username}</o:Username>
-        <o:Password>{password}</o:Password>
-      </o:UsernameToken>
-    </o:Security>
-  </s:Header>
-  <s:Body>
-    <t:RequestSecurityToken xmlns:t="http://schemas.xmlsoap.org/ws/2005/02/trust">
-      <wsp:AppliesTo xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
-        <a:EndpointReference>
-          <a:Address>{site}</a:Address>
-        </a:EndpointReference>
-      </wsp:AppliesTo>
-      <t:KeyType>http://schemas.xmlsoap.org/ws/2005/05/identity/NoProofKey</t:KeyType>
-      <t:RequestType>http://schemas.xmlsoap.org/ws/2005/02/trust/Issue</t:RequestType>
-      <t:TokenType>urn:oasis:names:tc:SAML:1.0:assertion</t:TokenType>
-    </t:RequestSecurityToken>
-  </s:Body>
+            xmlns:a="http://www.w3.org/2005/08/addressing"
+            xmlns:u="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
+    <s:Header>
+        <a:Action s:mustUnderstand="1">http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue</a:Action>
+        <a:ReplyTo>
+            <a:Address>http://www.w3.org/2005/08/addressing/anonymous</a:Address>
+        </a:ReplyTo>
+        <a:To s:mustUnderstand="1">https://login.microsoftonline.com/extSTS.srf</a:To>
+        <o:Security s:mustUnderstand="1"
+             xmlns:o="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+            <o:UsernameToken>
+                <o:Username>{username}</o:Username>
+                <o:Password>{password}</o:Password>
+            </o:UsernameToken>
+        </o:Security>
+    </s:Header>
+    <s:Body>
+        <t:RequestSecurityToken xmlns:t="http://schemas.xmlsoap.org/ws/2005/02/trust">
+            <wsp:AppliesTo xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy">
+                <a:EndpointReference>
+                    <a:Address>{site}</a:Address>
+                </a:EndpointReference>
+            </wsp:AppliesTo>
+            <t:KeyType>http://schemas.xmlsoap.org/ws/2005/05/identity/NoProofKey</t:KeyType>
+            <t:RequestType>http://schemas.xmlsoap.org/ws/2005/02/trust/Issue</t:RequestType>
+            <t:TokenType>urn:oasis:names:tc:SAML:1.0:assertion</t:TokenType>
+        </t:RequestSecurityToken>
+    </s:Body>
 </s:Envelope>

--- a/saml-templates/sp-updateDigest.xml
+++ b/saml-templates/sp-updateDigest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-   xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
-   xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-   <soap:Body>
-      <GetUpdatedFormDigest xmlns="http://schemas.microsoft.com/sharepoint/soap/" />
-   </soap:Body>
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Body>
+       <GetUpdatedFormDigest xmlns="http://schemas.microsoft.com/sharepoint/soap/" />
+    </soap:Body>
 </soap:Envelope>


### PR DESCRIPTION
@joemeneses @tschroedertlc

This replaces all regex matches with proper XML parsing, which will allow non-standard XML namespaces that apparently sometimes occur. It also includes a general tidy-up of the ADFS auth code.

@tschroedertlc this implements many of the same changes as your #26, which I will now close.

If you're able, please let me know if I've broken anything in the ADFS authentication as I don't have access to a server to test with.