### PR TITLE
Add session site to login check in load function

### DIFF
--- a/src/sharepy/auth/adfs.py
+++ b/src/sharepy/auth/adfs.py
@@ -24,9 +24,10 @@ class SharePointADFS(BaseAuth):
     def login(self, site):
         """Perform authentication steps"""
         self.site = site
-        self._get_token()
-        self._get_cookie()
-        self._get_digest()
+        got_token = self._get_token()
+        got_cookie = self._get_cookie()
+        refreshed = self._get_digest()
+        return all([got_token, got_cookie, refreshed])
 
     def refresh(self):
         return self._get_digest()
@@ -117,6 +118,8 @@ class SharePointADFS(BaseAuth):
 
             # Calculate digest expiry time
             self.expire = datetime.now() + timedelta(seconds=timeout)
+
+        return True
 
     def _buildcookie(self, cookies):
         """Create session cookie from response cookie dictionary"""

--- a/src/sharepy/auth/spol.py
+++ b/src/sharepy/auth/spol.py
@@ -22,9 +22,10 @@ class SharePointOnline(BaseAuth):
     def login(self, site):
         """Perform authentication steps"""
         self.site = site
-        self._get_token()
-        self._get_cookie()
-        self._get_digest()
+        got_token = self._get_token()
+        got_cookie = self._get_cookie()
+        refreshed = self._get_digest()
+        return all([got_token, got_cookie, refreshed])
 
     def refresh(self):
         return self._get_digest()
@@ -50,6 +51,7 @@ class SharePointOnline(BaseAuth):
             raise errors.AuthError.fromxml(root)
 
         self.token = token.text
+        return True
 
     def _get_cookie(self):
         """Request access cookie from sharepoint site"""
@@ -64,6 +66,7 @@ class SharePointOnline(BaseAuth):
 
         if response.status_code == requests.codes.ok:
             self.cookie = cookie
+            return True
         else:
             raise errors.AuthError('Authentication failed')
 
@@ -84,7 +87,9 @@ class SharePointOnline(BaseAuth):
             # Calculate digest expiry time
             self.expire = datetime.now() + timedelta(seconds=timeout)
 
-        return True
+            return True
+
+        return False
 
     def _buildcookie(self, cookies):
         """Create session cookie from response cookie dictionary"""

--- a/src/sharepy/session.py
+++ b/src/sharepy/session.py
@@ -7,6 +7,7 @@ import requests
 from . import __version__
 from . import auth
 from . import errors
+from sharepy.auth.base import BaseAuth
 
 
 def connect(site, username=None, password=None):
@@ -25,7 +26,7 @@ def load(filename='sp-session.pkl'):
         raise errors.SessionError('The session is not compatible with the current SharePy version')
 
     # Try to authenticate the saved session
-    if session.auth.refresh() or session.auth.login():
+    if session.auth.refresh() or session.auth.login(session.site):
         # Re-save session to prevent it going stale
         try:
             session.save(filename)
@@ -47,7 +48,7 @@ class SharePointSession(requests.Session):
       <Response [200]>
     """
 
-    def __init__(self, site=None, auth=None):
+    def __init__(self, site=None, auth: BaseAuth = None):
         super().__init__()
         self.version = __version__
 


### PR DESCRIPTION
The load function would crash because the session.auth.login() call requires a website, so I passed the session.site to it. There is still a bug in which the refresh() and login() methods both return `None`, but the load method checks these and expects `True` so they need to be updated to return a boolean.